### PR TITLE
Added Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ php:
   - '5.6'
   - '7.0'
   - '7.1'
+install: composer install
 script: composer cs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: php
+php:
+  - '5.6'
+  - '7.0'
+  - '7.1'
+script: composer cs


### PR DESCRIPTION
This PR enables testing per Travis CI.  
I am not sure on which environment the application is running so CI is running on PHP 5.6, 7.0 and 7.1.

To activate Travis for this repository you have to head over to https://travis-ci.org/, login with your Github account and activate it for this project.